### PR TITLE
Create a bin.ts for npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "README.md"
   ],
   "main": "./dist/index.js",
+  "bin": "./dist/bin.js",
   "scripts": {
     "build": "tsc",
     "test": "node dist/test"

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/node
+
+import * as fs from 'fs';
+import { exit } from 'process';
+import HLS from "./index";
+
+const args = process.argv.slice(2);
+
+var input = "";
+if (args[0] == "-") {
+    var stdinBuffer = fs.readFileSync(0);
+    input = stdinBuffer.toString();
+} else {
+    input = fs.readFileSync(args[0], "utf8")
+}
+
+const manifest = HLS(input);
+
+console.log(JSON.stringify(manifest, null, 2));


### PR DESCRIPTION
I needed to parse some HLS inside bash and all I was missing was this small shim to allow for a quick `curl test.hls | npx parse-hls - | jq '.variants[-1].uri'`

A file path could be passed in as the argument also like: `npx parse-hls ./examples/cnn-chunklist-live.m3u8`